### PR TITLE
Add route to redirect root path

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,14 @@ const PORT = 1234
 
 app.set('view engine', 'ejs');
 
+app.get('/', async (req, res) => {
+    try {
+        res.redirect('/login')
+    } catch (error) {
+        console.log(error)
+    }
+})
+
 app.get('/login', async (req, res) => {
     try {
         res.render('pages/login.ejs')


### PR DESCRIPTION
I noticed that when we run our app and go to the page via port 1234 we get the below:

![wrong routing](https://user-images.githubusercontent.com/31871338/101139230-acc43c00-362a-11eb-815e-94fcb1bf1111.gif)

This is because we did not set a root route. We are forced to type the route to the login page. 

In this case we had two choices: 

1. change our login route to the root.
2. Create a root route and redirect it to the login.

I choose 2 because it did not make sense to me to make the login page the root page. I felt its more descriptive for the login page route to be `/login`. 

After I create the route this is what happens when you go to `http://localhost:1234` after running the app:

![correct routing](https://user-images.githubusercontent.com/31871338/101139503-13495a00-362b-11eb-956c-a5a80546fe56.gif)
